### PR TITLE
Pr/collab/625

### DIFF
--- a/c/meterpreter/source/extensions/priv/namedpipe_efs.c
+++ b/c/meterpreter/source/extensions/priv/namedpipe_efs.c
@@ -49,8 +49,13 @@ DWORD elevate_via_namedpipe_efs(Remote* remote, Packet* packet)
 			BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_efs: RtlGetVersion failed");
 		}
 
-		// Windows Vista / Server 2008 and prior only supports \pipe\lsarpc endpoint
-		if ((os.dwMajorVersion < 6) || (os.dwMajorVersion == 6 && (os.dwMinorVersion == 0 || os.dwMinorVersion == 1))) {
+		
+		if (os.dwMajorVersion < 6) {
+			SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+			BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_efs: Windows versions older than 6.0 are unsupported");
+		}
+		// Windows Vista / Server 2008 only supports \pipe\lsarpc endpoint
+		else if ((os.dwMajorVersion == 6 && (os.dwMinorVersion == 0 || os.dwMinorVersion == 1))) {
 			if (!does_pipe_exist(L"\\\\.\\pipe\\lsarpc")) {
 				BREAK_ON_ERROR("[ELEVATE] elevate_via_namedpipe_efs: \\pipe\\lsarpc is not listening.");
 			}

--- a/c/meterpreter/source/extensions/priv/service.c
+++ b/c/meterpreter/source/extensions/priv/service.c
@@ -181,15 +181,15 @@ DWORD service_query_status( char* cpName, DWORD* dwState )
 
 		hService = OpenServiceA( hManager, cpName, SERVICE_QUERY_STATUS);
 		if( !hService ){
-			char buffer[1024];
-			_snprintf_s(buffer, sizeof(buffer), sizeof(buffer) - 1, "[SERVICE] service_query_status. OpenServiceA failed for %s ", cpName);
-			BREAK_ON_ERROR( buffer );
+			dwResult = GetLastError();
+			dprintf("[SERVICE] service_query_status. QueryServiceStatusEx failed for %s. error=%d (0x%x) ", cpName, dwResult, (ULONG_PTR)dwResult);
+			break;
 		}
 
 		if (!QueryServiceStatusEx(hService, SC_STATUS_PROCESS_INFO, (LPBYTE)&procInfo, sizeof(procInfo), &dwBytes)) {
-			char buffer[1024];
-			_snprintf_s(buffer, sizeof(buffer), sizeof(buffer) - 1, "[SERVICE] service_query_status. QueryServiceStatusEx failed for %s ", cpName);
-			BREAK_ON_ERROR( buffer );
+			dwResult = GetLastError();
+			dprintf("[SERVICE] service_query_status. QueryServiceStatusEx failed for %s. error=%d (0x%x) ", cpName, dwResult, (ULONG_PTR)dwResult);
+			break;
 		}
 		else {
 			*dwState = procInfo.dwCurrentState;
@@ -216,10 +216,10 @@ DWORD service_wait_for_status( char* cpName, DWORD dwStatus, DWORD dwMaxTimeout 
 	DWORD dwResult;
 	do {
 		dwResult = service_query_status(cpName, &dwCurrentStatus);
-		if (dwResult != ERROR_SUCCESS) {
+		if( dwResult != ERROR_SUCCESS ) {
 			break;
 		}
-		if (dwCurrentStatus == dwStatus) {
+		if( dwCurrentStatus == dwStatus ) {
 			break;
 		}
 		else {
@@ -228,7 +228,7 @@ DWORD service_wait_for_status( char* cpName, DWORD dwStatus, DWORD dwMaxTimeout 
 		}
 	} while (dwElapsed < dwMaxTimeout);
 
-	if ((dwResult == ERROR_SUCCESS) && (dwCurrentStatus != dwStatus)) {
+	if( (dwResult == ERROR_SUCCESS) && (dwCurrentStatus != dwStatus) ) {
 		dwResult = WAIT_TIMEOUT;
 		SetLastError(dwResult);
 	}


### PR DESCRIPTION
This makes a few changes.

1. It updates the mimikatz submodule to pull in your changes which should fix the build failure in the PR.
2. It cleans up and simplifies the logic a bit. 
3. Removes a debug message from the release builds by using `dprintf` instead of the `BREAK_ON_ERROR` macro.
4. Makes some minor whitespace changes to make it consistent with the rest of the services file.
5. Filters out Windows versions < 6.0 from technique 6 / the Named Pipe Impersonation (EfsPotato Variant).
    * While XP SP2 does not work as observed through testing and XP SP3 does, they unfortunately both share the same version number of 5.1.2600 so we can't filter out just XP SP2 without a more involved check.